### PR TITLE
fix: resolve pir idx gen

### DIFF
--- a/mpc4j-s2pc-pir/src/main/java/edu/alibaba/mpc4j/s2pc/pir/PirUtils.java
+++ b/mpc4j-s2pc-pir/src/main/java/edu/alibaba/mpc4j/s2pc/pir/PirUtils.java
@@ -253,7 +253,7 @@ public class PirUtils {
     public static void generateIndexInputFiles(int elementSize, int retrievalSize)
         throws IOException {
         MathPreconditions.checkPositive("retrievalSize", retrievalSize);
-        File clientInputFile = new File(getClientFileName(BYTES_CLIENT_PREFIX, retrievalSize));
+        File clientInputFile = new File(getClientFileName(BYTES_CLIENT_PREFIX, retrievalSize, elementSize));
         if (clientInputFile.exists()) {
             return;
         }
@@ -296,6 +296,10 @@ public class PirUtils {
      */
     public static String getClientFileName(String prefix, int setSize) {
         return MainPtoConfigUtils.getFileFolderName() + prefix + "_" + prefix + "_" + setSize + ".input";
+    }
+
+    public static String getClientFileName(String prefix, int setSize, int elementSize) {
+        return MainPtoConfigUtils.getFileFolderName() + prefix + "_" + prefix + "_" + setSize + "_" + elementSize + ".input";
     }
 
     /**

--- a/mpc4j-s2pc-pir/src/main/java/edu/alibaba/mpc4j/s2pc/pir/main/cppir/index/CpIdxPirMain.java
+++ b/mpc4j-s2pc-pir/src/main/java/edu/alibaba/mpc4j/s2pc/pir/main/cppir/index/CpIdxPirMain.java
@@ -246,7 +246,7 @@ public class CpIdxPirMain extends AbstractMainTwoPartyPto {
         taskId++;
         for (int setSizeIndex = 0; setSizeIndex < serverSetSizeNum; setSizeIndex++) {
             int serverSetSize = serverSetSizes[setSizeIndex];
-            List<Integer> indexList = readClientRetrievalIndexList(queryNum);
+            List<Integer> indexList = readClientRetrievalIndexList(queryNum, serverSetSize);
             runClient(clientRpc, serverParty, config, taskId, indexList, serverSetSize, entryBitLength, parallel, printWriter);
             taskId++;
         }
@@ -271,6 +271,22 @@ public class CpIdxPirMain extends AbstractMainTwoPartyPto {
         return indexList;
     }
 
+    private List<Integer> readClientRetrievalIndexList(int retrievalSize, int elementSize) throws IOException {
+        LOGGER.info("Client read retrieval list");
+        InputStreamReader inputStreamReader = new InputStreamReader(
+                new FileInputStream(PirUtils.getClientFileName(PirUtils.BYTES_CLIENT_PREFIX, retrievalSize, elementSize)),
+                CommonConstants.DEFAULT_CHARSET
+        );
+        BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+        List<Integer> indexList = bufferedReader.lines()
+                .map(Hex::decode)
+                .map(IntUtils::byteArrayToInt)
+                .collect(Collectors.toCollection(ArrayList::new));
+        bufferedReader.close();
+        inputStreamReader.close();
+        return indexList;
+    }
+
     private void warmupClient(Rpc clientRpc, Party serverParty, CpIdxPirConfig config, int taskId)
         throws IOException, MpcAbortException {
         LOGGER.info(
@@ -278,7 +294,7 @@ public class CpIdxPirMain extends AbstractMainTwoPartyPto {
             clientRpc.ownParty().getPartyName(), WARMUP_SERVER_SET_SIZE, WARMUP_ELEMENT_BIT_LENGTH, WARMUP_QUERY_NUM,
             false
         );
-        List<Integer> indexList = readClientRetrievalIndexList(WARMUP_QUERY_NUM);
+        List<Integer> indexList = readClientRetrievalIndexList(WARMUP_QUERY_NUM, WARMUP_SERVER_SET_SIZE);
         CpIdxPirClient client = CpIdxPirFactory.createClient(clientRpc, serverParty, config);
         client.setTaskId(taskId);
         client.setParallel(false);


### PR DESCRIPTION
根据数据库的大小和查询次数，设置不同的客户端索引文件，不然可能会发生查询超域错误